### PR TITLE
Add generic cross-compile support

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,10 @@ required. In addition, the M4 macro processor is necessary for generating the
 source files in the first place. On Ubuntu and similar systems, you can install
 the `m4` and `ivtools-dev` packages.
 
+If you are wanting to use a cross-compile toolchain, set the `TOOLCHAIN_PREFIX`
+environment variable to the prefix required to find the cross-compile tools,
+e.g. `${TOOLCHAIN_PREFIX}gcc` should be found for a cross-compiling `gcc`.
+
 Some benchmarks expect their inputs to be at very specific paths relative to the
 working directory, so it is recommended to change the working directory to the
 benchmark folder before executing it.

--- a/codes/Makefile
+++ b/codes/Makefile
@@ -7,7 +7,7 @@ all:
 	$(MAKE) -C apps/ocean/non_contiguous_partitions
 	$(MAKE) -C apps/radiosity
 	$(MAKE) -C apps/raytrace
-	# $(MAKE) -C apps/volrend
+	$(MAKE) -C apps/volrend
 	$(MAKE) -C apps/water-nsquared
 	$(MAKE) -C apps/water-spatial
 	$(MAKE) -C kernels/cholesky

--- a/codes/Makefile
+++ b/codes/Makefile
@@ -7,7 +7,7 @@ all:
 	$(MAKE) -C apps/ocean/non_contiguous_partitions
 	$(MAKE) -C apps/radiosity
 	$(MAKE) -C apps/raytrace
-	$(MAKE) -C apps/volrend
+	# $(MAKE) -C apps/volrend
 	$(MAKE) -C apps/water-nsquared
 	$(MAKE) -C apps/water-spatial
 	$(MAKE) -C kernels/cholesky

--- a/codes/Makefile.config
+++ b/codes/Makefile.config
@@ -1,5 +1,11 @@
-CC := gcc
-CFLAGS := -O2 -pthread -D_XOPEN_SOURCE=500 -D_POSIX_C_SOURCE=200112 -std=c11 -g -fno-strict-aliasing
+# Cross-compile changes by Thomas E. Hansen (CodingCellist) 2021-03-08
+
+CC := $(CROSS_COMPILE)gcc
+ifdef CROSS_COMPILE
+	CFLAGS := -O2 -pthread -D_XOPEN_SOURCE=500 -D_POSIX_C_SOURCE=200112 -std=c11 -g -fno-strict-aliasing -static
+else
+	CFLAGS := -O2 -pthread -D_XOPEN_SOURCE=500 -D_POSIX_C_SOURCE=200112 -std=c11 -g -fno-strict-aliasing
+endif
 LDFLAGS := -lm
 
 # BASEDIR needs to be set to the same directory as this Makefile

--- a/codes/Makefile.config
+++ b/codes/Makefile.config
@@ -1,11 +1,7 @@
 # Cross-compile changes by Thomas E. Hansen (CodingCellist) 2021-03-08
 
-CC := $(CROSS_COMPILE)gcc
-ifdef CROSS_COMPILE
-	CFLAGS := -O2 -pthread -D_XOPEN_SOURCE=500 -D_POSIX_C_SOURCE=200112 -std=c11 -g -fno-strict-aliasing -static
-else
-	CFLAGS := -O2 -pthread -D_XOPEN_SOURCE=500 -D_POSIX_C_SOURCE=200112 -std=c11 -g -fno-strict-aliasing
-endif
+CC := $(TOOLCHAIN_PREFIX)gcc
+CFLAGS := -O2 -pthread -D_XOPEN_SOURCE=500 -D_POSIX_C_SOURCE=200112 -std=c11 -g -fno-strict-aliasing
 LDFLAGS := -lm
 
 # BASEDIR needs to be set to the same directory as this Makefile

--- a/codes/apps/radiosity/Makefile
+++ b/codes/apps/radiosity/Makefile
@@ -35,3 +35,9 @@ glibdumb/glib.a:
 
 glibps/glibps.a:
 	$(MAKE) -C glibps
+
+clean:
+	$(MAKE) -C glibdumb clean
+	$(MAKE) -C glibps clean
+	$(RM) $(OBJS) RADIOSITY
+

--- a/codes/apps/radiosity/glibdumb/Makefile
+++ b/codes/apps/radiosity/glibdumb/Makefile
@@ -10,7 +10,7 @@ TARGET = glib.a
 include ../../../Makefile.config
 
 $(TARGET): $(OBJS)
-	$(CROSS_COMPILE)ar crv $(TARGET) $(OBJS)
+	$(TOOLCHAIN_PREFIX)ar crv $(TARGET) $(OBJS)
 
 clean:
 	rm -rf $(OBJS) $(TARGET)

--- a/codes/apps/radiosity/glibdumb/Makefile
+++ b/codes/apps/radiosity/glibdumb/Makefile
@@ -2,6 +2,7 @@
 #  Device independent graphics package GLIB.
 #  NULL graphic device version
 #
+# Cross-compile changes by Thomas E. Hansen (CodingCellist) 2021-03-08
 
 OBJS   = glib.o
 TARGET = glib.a
@@ -9,7 +10,7 @@ TARGET = glib.a
 include ../../../Makefile.config
 
 $(TARGET): $(OBJS)
-	ar crv $(TARGET) $(OBJS)
+	$(CROSS_COMPILE)ar crv $(TARGET) $(OBJS)
 
 clean:
 	rm -rf $(OBJS) $(TARGET)

--- a/codes/apps/radiosity/glibps/Makefile
+++ b/codes/apps/radiosity/glibps/Makefile
@@ -11,7 +11,7 @@ OBJS   = glibps.o
 include ../../../Makefile.config
 
 $(TARGET): $(OBJS)
-	$(CROSS_COMPILE)ar crv $(TARGET) $(OBJS)
+	$(TOOLCHAIN_PREFIX)ar crv $(TARGET) $(OBJS)
 
 clean:
 	rm -rf *.o $(TARGET)

--- a/codes/apps/radiosity/glibps/Makefile
+++ b/codes/apps/radiosity/glibps/Makefile
@@ -3,6 +3,7 @@
 #                        SUN/Xview version makefile
 #
 #
+# Cross-compile changes by Thomas E. Hansen (CodingCellist) 2021-03-08
 
 TARGET = glibps.a
 OBJS   = glibps.o
@@ -10,7 +11,7 @@ OBJS   = glibps.o
 include ../../../Makefile.config
 
 $(TARGET): $(OBJS)
-	ar crv $(TARGET) $(OBJS)
+	$(CROSS_COMPILE)ar crv $(TARGET) $(OBJS)
 
 clean:
 	rm -rf *.o $(TARGET)

--- a/codes/apps/volrend/Makefile
+++ b/codes/apps/volrend/Makefile
@@ -22,3 +22,8 @@ incl.h:	user_options.h const.h my_types.h global.h macros.h address.h
 
 libtiff/libtiff.a:
 	make -C libtiff
+
+clean:
+	$(MAKE) -C libtiff clean
+	$(RM) $(OBJS) VOLREND
+


### PR DESCRIPTION
Having previously needed to cross-compile this for use in simulation (but used a native platform for compilation, then copied the files), I have made an attempt at making this cross-compile in general.

There are some problems with getting `volrend`'s `libtiff` to cross-compile successfully, and I have been unable to resolve these. Any help would be greatly appreciated!