### PR TITLE
Ocean-non-contiguous: psibilock wrongly used

### DIFF
--- a/codes/apps/ocean/non_contiguous_partitions/slave2.c.in
+++ b/codes/apps/ocean/non_contiguous_partitions/slave2.c.in
@@ -714,9 +714,9 @@ void slave2(long procid, long firstrow, long lastrow, long numrows, long firstco
 /* after computing its private sum, every process adds that to the
    shared running sum psiai  */
 
-   LOCK(locks->psibilock)
+   LOCK(locks->psiailock)
    global->psiai = global->psiai + psiaipriv;
-   UNLOCK(locks->psibilock)
+   UNLOCK(locks->psiailock)
 
    BARRIER(bars->sl_phase_7,nprocs)
 


### PR DESCRIPTION
It is not relevant for correctness, but the lock used in "slave2.c.in:717-719" should be the `psiailock` instead of the `psibilock`. 
This can be confirmed in the ocean-contiguous_partitions where the same critical section use the correct lock.

The `psiailock` is meant to be used with the `global->psiai` variable 
The `psibilock` is meant to be used with the `global->psibi` variable